### PR TITLE
linux-intel: Fix HDMI audio

### DIFF
--- a/layers/meta-resin-up-board/recipes-kernel/linux/linux-intel_%.bbappend
+++ b/layers/meta-resin-up-board/recipes-kernel/linux/linux-intel_%.bbappend
@@ -8,3 +8,8 @@ RESIN_CONFIGS_DEPS[hdmi_lpe_audio] = " \
 RESIN_CONFIGS[hdmi_lpe_audio] = " \
     CONFIG_HDMI_LPE_AUDIO=m \
 "
+
+RESIN_CONFIGS_append = " hdmi_sound"
+RESIN_CONFIGS[hdmi_sound] = " \
+    CONFIG_SND_HDA_INTEL=m \
+"


### PR DESCRIPTION
This fixes the following error:
kernel: hdaudio hdaudioC0D2: Unable to bind the codec

Changelog-entry: Fix HDMI audio
Signed-off-by: Florin Sarbu <florin@balena.io>